### PR TITLE
Example of ambiguous instances for TwiddleOpTwo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.tools.mima.core._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion := "0.2"
+ThisBuild / tlBaseVersion := "0.3"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"

--- a/core/shared/src/main/scala/org/typelevel/twiddles/Twiddles.scala
+++ b/core/shared/src/main/scala/org/typelevel/twiddles/Twiddles.scala
@@ -53,11 +53,21 @@ trait TwiddleSyntax[F[_]] extends TwiddleSyntaxPlatform[F] {
 object syntax extends TwiddleSyntaxGeneric
 
 final class TwiddleOpCons[F[_], B <: Tuple](private val self: F[B]) extends AnyVal {
+  // Workaround for https://github.com/typelevel/twiddles/pull/2
+  def *:[A](fa: F[A])(implicit F: InvariantSemigroupal[F], ev: DummyImplicit): F[A *: B] =
+    *:[F, A](fa)(F)
+
   def *:[G[x] >: F[x], A](ga: G[A])(implicit G: InvariantSemigroupal[G]): G[A *: B] =
     ga.product(self).imap[A *: B] { case (hd, tl) => hd *: tl } { case hd *: tl => (hd, tl) }
 }
 
 final class TwiddleOpTwo[F[_], B](private val self: F[B]) extends AnyVal {
+  // Workaround for https://github.com/typelevel/twiddles/pull/2
+  def *:[A](
+      fa: F[A]
+  )(implicit F: InvariantSemigroupal[F], ev: DummyImplicit): F[A *: B *: EmptyTuple] =
+    *:[F, A](fa)(F)
+
   def *:[G[x] >: F[x], A](ga: G[A])(implicit G: InvariantSemigroupal[G]): G[A *: B *: EmptyTuple] =
     ga.product(self).imap[A *: B *: EmptyTuple] { case (a, b) => a *: b *: EmptyTuple } {
       case a *: b *: EmptyTuple => (a, b)

--- a/core/shared/src/test/scala/examples/Hierarchy.scala
+++ b/core/shared/src/test/scala/examples/Hierarchy.scala
@@ -65,4 +65,5 @@ object Hierarchy {
   def f: Encoder[Foo] = (int *: (string: Encoder[String]) *: bool).as[Foo]
   def g: Encoder[Foo] = ((int: Encoder[Int]) *: string *: bool).as[Foo]
   def h = (int *: string) *: bool
+  def i = (int *: string *: bool) *: bool *: bool
 }

--- a/core/shared/src/test/scala/examples/Hierarchy.scala
+++ b/core/shared/src/test/scala/examples/Hierarchy.scala
@@ -64,4 +64,5 @@ object Hierarchy {
   def e: Encoder[Foo] = (int *: string *: (bool: Encoder[Boolean])).as[Foo]
   def f: Encoder[Foo] = (int *: (string: Encoder[String]) *: bool).as[Foo]
   def g: Encoder[Foo] = ((int: Encoder[Int]) *: string *: bool).as[Foo]
+  def h = (int *: string) *: bool
 }


### PR DESCRIPTION
Adding `def h = (int *: string) *: bool` to `Hierarchy.scala` example results in the following error on Scala 3:

```
[error] -- Error: /Development/oss/twiddles/core/shared/src/test/scala/examples/Hierarchy.scala:67:24 
[error] 67 |  def h = (int *: string) *: bool
[error]    |                        ^
[error]    |Ambiguous given instances: both method instance in object Codec and method instance in object Encoder match type cats.InvariantSemigroupal[G] of parameter G of method *: in class TwiddleOpTwo
[error] one error found
[error] (Test / compileIncremental) Compilation failed
```

It works fine on Scala 2. It also works if you split in to two expressions like:

```scala
def h = int *: string
def i = h *: bool
```