### PR TITLE
Replace as method with to method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ val a = Option(42)
 val b = Option("Hi")
 // b: Option[String] = Some(value = "Hi")
 
-val foo = (a *: b).as[Foo]
+val foo = (a *: b).to[Foo]
 // foo: Option[Foo] = Some(value = Foo(x = 42, y = "Hi"))
 ```
 
-In this example, `a *: b` creates an `Option[Int *: String *: EmptyTuple]`. We then convert that value to an `Option[Foo]` via `.as[Foo]`.
+In this example, `a *: b` creates an `Option[Int *: String *: EmptyTuple]`. We then convert that value to an `Option[Foo]` via `.to[Foo]`.
 
 The `*:` operation comes from the imported twiddle syntax and is similar to the Scala 3 built-in tuple cons operation, but works on applied type constructors. The expression `a *: b *: c` builds an `F[A *: B *: C *: EmptyTuple]` from an `F[A]`, `F[B]`, and `F[C]`. The `*:` operation requires that the type constructor `F` has a `cats.InvariantSemigroupal` instance.
 
-The `as` operation also comes from the imported twiddle syntax. Calling `.as[X]` on an `F[T]` for some twiddle list `T` results in an `F[X]` provided that `T` is shape compatible with `X`. In the most common case where `X` is a case class, shape compatibility is defined as `T` having the same types in the same order as the parameters of `X`. The `as` operation requires that the type constructor `F` has a `cats.Invariant` instance.
+The `to` operation also comes from the imported twiddle syntax. Calling `.to[X]` on an `F[T]` for some twiddle list `T` results in an `F[X]` provided that `T` is shape compatible with `X`. In the most common case where `X` is a case class, shape compatibility is defined as `T` having the same types in the same order as the parameters of `X`. The `to` operation requires that the type constructor `F` has a `cats.Invariant` instance.
 
 Invariant semigroupals are much more general than (covariant) functors, which means twiddle list support works for a wide variety of data types. For instance, contravariant functors are invariant semigroupals allowing us to use twiddle list syntax to incrementally build instances:
 
 ```scala
-val fooOrdering = (summon[Ordering[Int]] *: summon[Ordering[String]]).as[Foo]
-// fooOrdering: Ordering[Foo] = scala.math.Ordering$$anon$1@53b6c31c
+val fooOrdering = (summon[Ordering[Int]] *: summon[Ordering[String]]).to[Foo]
+// fooOrdering: Ordering[Foo] = scala.math.Ordering$$anon$1@39e8f45c
 ```
 
 ## Library Usage
@@ -60,16 +60,16 @@ object Decoder extends TwiddleSyntax[Decoder] {
 }
 
 val int: Decoder[Int] = _ => ???
-// int: Decoder[Int] = repl.MdocSession$MdocApp0$$Lambda$21673/0x0000000804034ee8@25630c4e
+// int: Decoder[Int] = repl.MdocSession$MdocApp0$$Lambda$14766/0x0000000802b78ee8@47e1cada
 val string: Decoder[String] = _ => ???
-// string: Decoder[String] = repl.MdocSession$MdocApp0$$Lambda$21674/0x0000000804035330@51372ab7
+// string: Decoder[String] = repl.MdocSession$MdocApp0$$Lambda$14767/0x0000000802b79330@38938c5d
 
 case class Foo(x: Int, y: String)
-val fooDecoder = (int *: string).as[Foo]
-// fooDecoder: Decoder[Foo] = repl.MdocSession$$anon$8$$Lambda$21677/0x0000000804036000@50615327
+val fooDecoder = (int *: string).to[Foo]
+// fooDecoder: Decoder[Foo] = repl.MdocSession$$anon$8$$Lambda$14770/0x0000000802b7a000@613596db
 ```
 
-In this example, the `Decoder` type has an `Applicative` instance defined in its companion object (and `Applicative` extends `InvariantSemigroupal`), and the companion object extends `TwiddleSyntax`. The latter enables use of `*:` and `as` with `Decoder` values without adding explicit imports (that is, there's no need to import `org.typelevel.twiddles.syntax._` at call sites).
+In this example, the `Decoder` type has an `Applicative` instance defined in its companion object (and `Applicative` extends `InvariantSemigroupal`), and the companion object extends `TwiddleSyntax`. The latter enables use of `*:` and `to` with `Decoder` values without adding explicit imports (that is, there's no need to import `org.typelevel.twiddles.syntax._` at call sites).
 
 ## Etymology
 

--- a/core/shared/src/main/scala/org/typelevel/twiddles/Twiddles.scala
+++ b/core/shared/src/main/scala/org/typelevel/twiddles/Twiddles.scala
@@ -38,7 +38,7 @@ trait TwiddleSyntax[F[_]] extends TwiddleSyntaxPlatform[F] {
     fb
   )
   implicit def toTwiddleOpTwo[B](fb: F[B]): TwiddleOpTwo[F, B] = new TwiddleOpTwo(fb)
-  implicit def toTwiddleOpAs[A](fa: F[A]): TwiddleOpAs[F, A] = new TwiddleOpAs(fa)
+  implicit def toTwiddleOpTo[A](fa: F[A]): TwiddleOpTo[F, A] = new TwiddleOpTo(fa)
 }
 
 object syntax extends TwiddleSyntaxGenericPlatform {
@@ -46,7 +46,7 @@ object syntax extends TwiddleSyntaxGenericPlatform {
     fb
   )
   implicit def toTwiddleOpTwo[F[_], B](fb: F[B]): TwiddleOpTwo[F, B] = new TwiddleOpTwo(fb)
-  implicit def toTwiddleOpAs[F[_], A](fa: F[A]): TwiddleOpAs[F, A] = new TwiddleOpAs(fa)
+  implicit def toTwiddleOpTo[F[_], A](fa: F[A]): TwiddleOpTo[F, A] = new TwiddleOpTo(fa)
 }
 
 final class TwiddleOpCons[F[_], B <: Tuple](private val self: F[B]) extends AnyVal {
@@ -71,6 +71,6 @@ final class TwiddleOpTwo[F[_], B](private val self: F[B]) extends AnyVal {
       case a *: b *: EmptyTuple => (a, b)
     }
 }
-final class TwiddleOpAs[F[_], A](private val self: F[A]) extends AnyVal {
-  def as[B](implicit iso: Iso[A, B], F: Invariant[F]): F[B] = self.imap(iso.to)(iso.from)
+final class TwiddleOpTo[F[_], A](private val self: F[A]) extends AnyVal {
+  def to[B](implicit iso: Iso[A, B], F: Invariant[F]): F[B] = self.imap(iso.to)(iso.from)
 }

--- a/core/shared/src/test/scala/examples/Example.scala
+++ b/core/shared/src/test/scala/examples/Example.scala
@@ -54,16 +54,16 @@ object Example {
   val string: Decoder[String] = _ => ???
 
   case class Foo(x: Int, y: String)
-  val fooDecoder: Decoder[Foo] = (int *: string).as[Foo]
+  val fooDecoder: Decoder[Foo] = (int *: string).to[Foo]
 
   case class Bar(x: Int)
-  val barDecoder: Decoder[Bar] = int.as[Bar]
+  val barDecoder: Decoder[Bar] = int.to[Bar]
 
   case class Baz(x: Foo, y: Bar)
-  val bazDecoder = (fooDecoder *: barDecoder).as[Baz]
+  val bazDecoder = (fooDecoder *: barDecoder).to[Baz]
 
   val unit: Decoder[Unit] = _ => ???
-  val fooDecoder2 = (int *: unit *: string *: unit).as[Foo]
+  val fooDecoder2 = (int *: unit *: string *: unit).to[Foo]
 
   val dropping: Decoder[Int *: String *: EmptyTuple] =
     (int *: unit *: string *: unit).dropUnits
@@ -75,4 +75,10 @@ object Example {
   bar(1 *: "hi" *: true *: EmptyTuple)
 
   val bazIso = Iso.product[Baz]
+
+  {
+    // Make sure there's no conflict with cats syntax
+    import cats.syntax.all.*
+    val _: Decoder[Foo] = (int *: string).to[Foo]
+  }
 }

--- a/core/shared/src/test/scala/examples/Hierarchy.scala
+++ b/core/shared/src/test/scala/examples/Hierarchy.scala
@@ -57,13 +57,13 @@ object Hierarchy {
 
   case class Foo(x: Int, y: String, z: Boolean)
 
-  def a: Codec[Foo] = (int *: string *: bool).as[Foo]
-  def b: Decoder[Foo] = (int *: string *: (bool: Decoder[Boolean])).as[Foo]
-  def c: Decoder[Foo] = (int *: (string: Decoder[String]) *: bool).as[Foo]
-  def d: Decoder[Foo] = ((int: Decoder[Int]) *: string *: bool).as[Foo]
-  def e: Encoder[Foo] = (int *: string *: (bool: Encoder[Boolean])).as[Foo]
-  def f: Encoder[Foo] = (int *: (string: Encoder[String]) *: bool).as[Foo]
-  def g: Encoder[Foo] = ((int: Encoder[Int]) *: string *: bool).as[Foo]
+  def a: Codec[Foo] = (int *: string *: bool).to[Foo]
+  def b: Decoder[Foo] = (int *: string *: (bool: Decoder[Boolean])).to[Foo]
+  def c: Decoder[Foo] = (int *: (string: Decoder[String]) *: bool).to[Foo]
+  def d: Decoder[Foo] = ((int: Decoder[Int]) *: string *: bool).to[Foo]
+  def e: Encoder[Foo] = (int *: string *: (bool: Encoder[Boolean])).to[Foo]
+  def f: Encoder[Foo] = (int *: (string: Encoder[String]) *: bool).to[Foo]
+  def g: Encoder[Foo] = ((int: Encoder[Int]) *: string *: bool).to[Foo]
   def h = (int *: string) *: bool
   def i = (int *: string *: bool) *: bool *: bool
 }

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -17,19 +17,19 @@ case class Foo(x: Int, y: String)
 val a = Option(42)
 val b = Option("Hi")
 
-val foo = (a *: b).as[Foo]
+val foo = (a *: b).to[Foo]
 ```
 
-In this example, `a *: b` creates an `Option[Int *: String *: EmptyTuple]`. We then convert that value to an `Option[Foo]` via `.as[Foo]`.
+In this example, `a *: b` creates an `Option[Int *: String *: EmptyTuple]`. We then convert that value to an `Option[Foo]` via `.to[Foo]`.
 
 The `*:` operation comes from the imported twiddle syntax and is similar to the Scala 3 built-in tuple cons operation, but works on applied type constructors. The expression `a *: b *: c` builds an `F[A *: B *: C *: EmptyTuple]` from an `F[A]`, `F[B]`, and `F[C]`. The `*:` operation requires that the type constructor `F` has a `cats.InvariantSemigroupal` instance.
 
-The `as` operation also comes from the imported twiddle syntax. Calling `.as[X]` on an `F[T]` for some twiddle list `T` results in an `F[X]` provided that `T` is shape compatible with `X`. In the most common case where `X` is a case class, shape compatibility is defined as `T` having the same types in the same order as the parameters of `X`. The `as` operation requires that the type constructor `F` has a `cats.Invariant` instance.
+The `to` operation also comes from the imported twiddle syntax. Calling `.to[X]` on an `F[T]` for some twiddle list `T` results in an `F[X]` provided that `T` is shape compatible with `X`. In the most common case where `X` is a case class, shape compatibility is defined as `T` having the same types in the same order as the parameters of `X`. The `to` operation requires that the type constructor `F` has a `cats.Invariant` instance.
 
 Invariant semigroupals are much more general than (covariant) functors, which means twiddle list support works for a wide variety of data types. For instance, contravariant functors are invariant semigroupals allowing us to use twiddle list syntax to incrementally build instances:
 
 ```scala mdoc
-val fooOrdering = (summon[Ordering[Int]] *: summon[Ordering[String]]).as[Foo]
+val fooOrdering = (summon[Ordering[Int]] *: summon[Ordering[String]]).to[Foo]
 ```
 
 ## Library Usage
@@ -59,10 +59,10 @@ val int: Decoder[Int] = _ => ???
 val string: Decoder[String] = _ => ???
 
 case class Foo(x: Int, y: String)
-val fooDecoder = (int *: string).as[Foo]
+val fooDecoder = (int *: string).to[Foo]
 ```
 
-In this example, the `Decoder` type has an `Applicative` instance defined in its companion object (and `Applicative` extends `InvariantSemigroupal`), and the companion object extends `TwiddleSyntax`. The latter enables use of `*:` and `as` with `Decoder` values without adding explicit imports (that is, there's no need to import `org.typelevel.twiddles.syntax._` at call sites).
+In this example, the `Decoder` type has an `Applicative` instance defined in its companion object (and `Applicative` extends `InvariantSemigroupal`), and the companion object extends `TwiddleSyntax`. The latter enables use of `*:` and `to` with `Decoder` values without adding explicit imports (that is, there's no need to import `org.typelevel.twiddles.syntax._` at call sites).
 
 ## Etymology
 


### PR DESCRIPTION
The `as` method conflicts with the `Functor` operation by the same name -- i.e. alias for `fa.as(b) == fa.map(_ => b)`.