### PR TITLE
Simplify Scala 3 extension methods (not yet compiling)

### DIFF
--- a/core/shared/src/main/scala-3/org/typelevel/twiddles/Twiddles.scala
+++ b/core/shared/src/main/scala-3/org/typelevel/twiddles/Twiddles.scala
@@ -72,24 +72,3 @@ object syntax:
     inline def dropUnits(using Invariant[F]): F[DropUnits[A]] =
       fa.imap(DropUnits.drop(_))(DropUnits.insert(_))
 
-final class TwiddleOpCons[F[_], B <: Tuple](private val self: F[B]) extends AnyVal:
-  // Workaround for https://github.com/typelevel/twiddles/pull/2
-  @annotation.targetName("consFixedF")
-  def *:[A](fa: F[A])(using F: InvariantSemigroupal[F]): F[A *: B] =
-    *:[F, A](fa)(using F)
-
-  def *:[G[x] >: F[x], A](ga: G[A])(using InvariantSemigroupal[G]): G[A *: B] =
-    ga.product(self).imap[A *: B] { case (hd, tl) => hd *: tl } { case hd *: tl => (hd, tl) }
-
-final class TwiddleOpTwo[F[_], B](private val self: F[B]) extends AnyVal:
-  // Workaround for https://github.com/typelevel/twiddles/pull/2
-  @annotation.targetName("twoFixedF")
-  def *:[A](
-      fa: F[A]
-  )(using F: InvariantSemigroupal[F]): F[A *: B *: EmptyTuple] =
-    *:[F, A](fa)(using F)
-
-  def *:[G[x] >: F[x], A](ga: G[A])(using InvariantSemigroupal[G]): G[A *: B *: EmptyTuple] =
-    ga.product(self).imap[A *: B *: EmptyTuple] { case (a, b) => a *: b *: EmptyTuple } {
-      case a *: b *: EmptyTuple => (a, b)
-    }


### PR DESCRIPTION
Starting point for #10. The simplified extension methods here don't work for all hierarchy cases:

```scala
[error] -- [E007] Type Mismatch Error: /Users/mpilquist/Development/oss/twiddles/core/shared/src/test/scala/examples/Hierarchy.scala:62:33
[error] 62 |  def c: Decoder[Foo] = (int *: (string: Decoder[String]) *: bool).to[Foo]
[error]    |                                 ^^^^^^^^^^^^^^^^^^^^^^^
[error]    |                         Found:    examples.Hierarchy.Decoder[String]
[error]    |                         Required: examples.Hierarchy.Codec[A]
[error]    |
[error]    |                         where:    A is a type variable with constraint
[error]    |
[error]    | longer explanation available when compiling with `-explain`
[error] -- [E007] Type Mismatch Error: /Users/mpilquist/Development/oss/twiddles/core/shared/src/test/scala/examples/Hierarchy.scala:63:26
[error] 63 |  def d: Decoder[Foo] = ((int: Decoder[Int]) *: string *: bool).to[Foo]
[error]    |                          ^^^^^^^^^^^^^^^^^
[error]    |                         Found:    examples.Hierarchy.Decoder[Int]
[error]    |                         Required: examples.Hierarchy.Codec[A]
[error]    |
[error]    |                         where:    A is a type variable with constraint
[error]    |
[error]    | longer explanation available when compiling with `-explain`
[error] -- [E007] Type Mismatch Error: /Users/mpilquist/Development/oss/twiddles/core/shared/src/test/scala/examples/Hierarchy.scala:65:33
[error] 65 |  def f: Encoder[Foo] = (int *: (string: Encoder[String]) *: bool).to[Foo]
[error]    |                                 ^^^^^^^^^^^^^^^^^^^^^^^
[error]    |                         Found:    examples.Hierarchy.Encoder[String]
[error]    |                         Required: examples.Hierarchy.Codec[A]
[error]    |
[error]    |                         where:    A is a type variable with constraint
[error]    |
[error]    | longer explanation available when compiling with `-explain`
[error] -- [E007] Type Mismatch Error: /Users/mpilquist/Development/oss/twiddles/core/shared/src/test/scala/examples/Hierarchy.scala:66:26
[error] 66 |  def g: Encoder[Foo] = ((int: Encoder[Int]) *: string *: bool).to[Foo]
[error]    |                          ^^^^^^^^^^^^^^^^^
[error]    |                         Found:    examples.Hierarchy.Encoder[Int]
[error]    |                         Required: examples.Hierarchy.Codec[A]
[error]    |
[error]    |                         where:    A is a type variable with constraint
[error]    |
[error]    | longer explanation available when compiling with `-explain`
[error] four errors found
```