### PR TITLE
Fix slow Scala2 subtype check for long twiddles

### DIFF
--- a/core/jvm/src/test/scala-2/org/typelevel/twiddles/test/CompilationPerformanceSpec.scala
+++ b/core/jvm/src/test/scala-2/org/typelevel/twiddles/test/CompilationPerformanceSpec.scala
@@ -61,6 +61,36 @@ class CompilationPerformanceSpec extends FunSuite {
     assert(compiled.isInstanceOf[Tuple])
   }
 
+  test("should subtype in a reasonable amount of time") {
+    val compiled = compileWithin(
+      q"""import org.typelevel.twiddles._
+          val inferred =
+            1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *:
+            1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *:
+            1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *:
+            1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *:
+            1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *:
+            1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *:
+            1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *:
+            1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *: 1 *:
+              EmptyTuple
+          type Expected = 
+            Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *:
+            Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *:
+            Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *:
+            Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *:
+            Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *:
+            Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *:
+            Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *:
+            Int *: Int *: Int *: Int *: Int *: Int *: Int *: Int *:
+              EmptyTuple
+          inferred: Expected""",
+      10.seconds
+    )
+
+    assert(compiled.isInstanceOf[Tuple])
+  }
+
   private val toolbox = {
     val toolbox = currentMirror.mkToolBox()
     // warmup

--- a/core/shared/src/main/scala-2/org/typelevel/twiddles/TwiddleCompat.scala
+++ b/core/shared/src/main/scala-2/org/typelevel/twiddles/TwiddleCompat.scala
@@ -42,7 +42,7 @@ trait TwiddleCompat {
   type EmptyTuple = HNil
   @inline val EmptyTuple: EmptyTuple = HNil
 
-  type *:[A, B <: Tuple] = ::[A, B]
+  type *:[+A, +B <: Tuple] = ::[A, B]
   @inline val *: = ::
 
   implicit def toTupleOps[T <: Tuple](t: T): TupleOps[T] =


### PR DESCRIPTION
Resolves typelevel/twiddles#15