### PR TITLE
Restore old implementation of *: on Scala 3 to restore compatibility with opaque types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,9 +23,6 @@ ThisBuild / licenses := List(
   ("BSD-3-Clause", url("https://github.com/typelevel/twiddles/blob/main/LICENSE"))
 )
 
-// Not sure why this seems to be necessary?
-ThisBuild / tlMimaPreviousVersions += "1.0.0"
-
 ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[DirectMissingMethodProblem](
     "org.typelevel.twiddles.TwiddleSyntax.twiddlesPrependOps"

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,9 @@ ThisBuild / licenses := List(
   ("BSD-3-Clause", url("https://github.com/typelevel/twiddles/blob/main/LICENSE"))
 )
 
+// Not sure why this seems to be necessary?
+ThisBuild / tlMimaPreviousVersions += "1.0.0"
+
 ThisBuild / mimaBinaryIssueFilters ++= Seq(
   ProblemFilters.exclude[DirectMissingMethodProblem](
     "org.typelevel.twiddles.TwiddleSyntax.twiddlesPrependOps"

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.typesafe.tools.mima.core._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion := "1.0"
+ThisBuild / tlBaseVersion := "1.1"
 
 ThisBuild / organization := "org.typelevel"
 ThisBuild / organizationName := "Typelevel"
@@ -24,6 +24,12 @@ ThisBuild / licenses := List(
 )
 
 ThisBuild / mimaBinaryIssueFilters ++= Seq(
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "org.typelevel.twiddles.TwiddleSyntax.twiddlesPrependOps"
+  ),
+  ProblemFilters.exclude[MissingClassProblem](
+    "org.typelevel.twiddles.TwiddleSyntax$twiddlesPrependOps$"
+  )
 )
 
 lazy val root = tlCrossRootProject

--- a/core/shared/src/main/scala-3/org/typelevel/twiddles/Twiddles.scala
+++ b/core/shared/src/main/scala-3/org/typelevel/twiddles/Twiddles.scala
@@ -36,10 +36,13 @@ import scala.compiletime.summonInline
 
 object Twiddles:
 
+  // See https://github.com/typelevel/twiddles/issues/146
+  @deprecated("Prepend is deprecated as it is incompatible with opaque types", "1.1.0")
   type Prepend[A, B] = B match
     case Tuple => A *: B
     case _     => A *: B *: EmptyTuple
 
+  @deprecated("prepend is a deprecated implementation detail", "1.1.0")
   inline def prepend[F[x]: InvariantSemigroupal, G[x] <: F[x], A, B](
       fa: F[A],
       gb: G[B]
@@ -55,18 +58,23 @@ object Twiddles:
         val res = fa.product(gb)
         res.asInstanceOf[F[Prepend[A, B]]]
 
+  @deprecated("PrependOps is a deprecated implementation detail", "1.1.0")
   sealed trait PrependOps[F[_]]:
     extension [A](self: F[A])(using InvariantSemigroupal[F])
       inline def *:[B](that: F[B]): F[Prepend[A, B]] =
-        prepend(self, that)
+        ??? // Unreachable, kept for bincompat
 
     extension [A, G[x] >: F[x]: InvariantSemigroupal](self: G[A])
       inline def *:[B](that: F[B]): G[Prepend[A, B]] =
-        prepend(self, that)
+        ??? // Unreachable, kept for bincompat
 
 trait TwiddleSyntax[F[_]]:
 
-  given twiddlesPrependOps: Twiddles.PrependOps[F] with {}
+  implicit def toTwiddleOpCons[B <: Tuple](fb: F[B]): TwiddleOpCons[F, B] = new TwiddleOpCons(
+    fb
+  )
+
+  implicit def toTwiddleOpTwo[B](fb: F[B]): TwiddleOpTwo[F, B] = new TwiddleOpTwo(fb)
 
   extension [A](fa: F[A])
 
@@ -87,7 +95,15 @@ object syntax:
     inline def *:[G[x] >: F[x], B](gb: G[B])(using
         InvariantSemigroupal[G]
     ): G[A *: B *: EmptyTuple] =
-      Twiddles.prepend(fa, gb).asInstanceOf[G[A *: B *: EmptyTuple]]
+      inline gb match
+        case gbT: G[bh *: bt] =>
+          val gbT0: G[bh *: bt] = gbT
+          val res = fa.product(gbT0).imap[A *: bh *: bt] { case (hd, tl) => hd *: tl } {
+            case hd *: tl => (hd, tl)
+          }
+          res.asInstanceOf[G[A *: B *: EmptyTuple]]
+        case _ =>
+          fa.product(gb).asInstanceOf[G[A *: B *: EmptyTuple]]
 
     inline def to[B](using iso: Iso[A, B], F: Invariant[F]): F[B] =
       fa.imap(iso.to)(iso.from)
@@ -95,3 +111,30 @@ object syntax:
   extension [F[_], A <: Tuple](fa: F[A])
     inline def dropUnits(using Invariant[F]): F[DropUnits[A]] =
       fa.imap(DropUnits.drop(_))(DropUnits.insert(_))
+
+  implicit def toTwiddleOpCons[F[_], B <: Tuple](fb: F[B]): TwiddleOpCons[F, B] =
+    new TwiddleOpCons(fb)
+
+  implicit def toTwiddleOpTwo[F[_], B](fb: F[B]): TwiddleOpTwo[F, B] = new TwiddleOpTwo(fb)
+
+final class TwiddleOpCons[F[_], B <: Tuple](private val self: F[B]) extends AnyVal:
+  // Workaround for https://github.com/typelevel/twiddles/pull/2
+  @annotation.targetName("consFixedF")
+  def *:[A](fa: F[A])(using F: InvariantSemigroupal[F]): F[A *: B] =
+    *:[F, A](fa)(using F)
+
+  def *:[G[x] >: F[x], A](ga: G[A])(using InvariantSemigroupal[G]): G[A *: B] =
+    ga.product(self).imap[A *: B] { case (hd, tl) => hd *: tl } { case hd *: tl => (hd, tl) }
+
+final class TwiddleOpTwo[F[_], B](private val self: F[B]) extends AnyVal:
+  // Workaround for https://github.com/typelevel/twiddles/pull/2
+  @annotation.targetName("twoFixedF")
+  def *:[A](
+      fa: F[A]
+  )(using F: InvariantSemigroupal[F]): F[A *: B *: EmptyTuple] =
+    *:[F, A](fa)(using F)
+
+  def *:[G[x] >: F[x], A](ga: G[A])(using InvariantSemigroupal[G]): G[A *: B *: EmptyTuple] =
+    ga.product(self).imap[A *: B *: EmptyTuple] { case (a, b) => a *: b *: EmptyTuple } {
+      case a *: b *: EmptyTuple => (a, b)
+    }

--- a/core/shared/src/test/scala-3/examples/Opaques.scala
+++ b/core/shared/src/test/scala-3/examples/Opaques.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023, Typelevel
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package examples
+
+import cats.InvariantSemigroupal
+import org.typelevel.twiddles.TwiddleSyntax
+
+object Opaques:
+  trait Codec[A]
+  object Codec extends TwiddleSyntax[Codec]:
+    given InvariantSemigroupal[Codec] = ???
+
+  def int: Codec[Int] = ???
+
+  object Scope:
+    opaque type OpaqueInt = Int
+    val oint: Codec[OpaqueInt] = int
+
+  case class Foo(x: Int, y: Scope.OpaqueInt)
+
+  val a: Codec[Foo] = (int *: Scope.oint).to[Foo]
+
+  case class Bar(x: Int, y: Scope.OpaqueInt, z: Scope.OpaqueInt)
+
+  val b: Codec[Bar] = (int *: Scope.oint *: Scope.oint).to[Bar]
+

--- a/core/shared/src/test/scala-3/examples/Opaques.scala
+++ b/core/shared/src/test/scala-3/examples/Opaques.scala
@@ -51,4 +51,3 @@ object Opaques:
   case class Bar(x: Int, y: Scope.OpaqueInt, z: Scope.OpaqueInt)
 
   val b: Codec[Bar] = (int *: Scope.oint *: Scope.oint).to[Bar]
-


### PR DESCRIPTION
Fixes #146.

The implementation of `*:` introduced in #140 relied on a match type:

```scala
type Prepend[A, B] = B match
  case Tuple => A *: B
  case _     => A *: B *: EmptyTuple
```

Given a `Prepend[X, Y]` where `Y` is an opaque type (or like in the original report in #146, an abstract type), the compiler cannot refute that `Y` is a `Tuple` so does no further reduction beyond `Prepend[X, Y]`.

Hence, the technique based on `Prepend` is fundamentally flawed. This PR restores the older implementation based on implicit classes.